### PR TITLE
Remove unnecessary parts of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,9 @@ sudo: required
 dist: trusty
 cache: packages
 
-python:
-  - "2.7"
-
 before_install:
   - pip install numpy mwparserfromhell
 
-env:
- global:
-   - CRAN: http://cran.rstudio.com
-r_packages:
-   - testthat
-   - reticulate
-   - devtools
 notifications:
   email:
     on_failure: change


### PR DESCRIPTION
I am pretty sure `python:` will only do something if `lang: python`, not in `lang: r`. Setting a CRAN mirror is not necessary (it will use 'https://cloud.r-project.org' by default) and you should basically never need to use `r_packages`, just list the R dependencies appropriately in your `DESCRIPTION` (as they already are).